### PR TITLE
Add a constructor for the now abstract error type.

### DIFF
--- a/drivers/generic/ppx_protocol_driver.ml
+++ b/drivers/generic/ppx_protocol_driver.ml
@@ -73,6 +73,8 @@ module Make(Driver: Driver)(P: Parameters) = struct
   type error = string * t option
   exception Protocol_error of error
 
+  let make_error ?value msg = (msg, value)
+
   let error_to_string_hum: error -> string = function
     | (s, Some t) -> Printf.sprintf "%s. Got: %s" s (Driver.to_string_hum t)
     | (s, None) -> s

--- a/drivers/xml_light/xml_light.ml
+++ b/drivers/xml_light/xml_light.ml
@@ -6,6 +6,8 @@ type t = Xml.xml
 type error = string * t option
 exception Protocol_error of error
 
+let make_error ?value msg = (msg, value)
+
 let to_string_hum xml = Xml.to_string_fmt xml
 
 let error_to_string_hum: error -> string = function

--- a/ppx/test/test_driver.ml
+++ b/ppx/test/test_driver.ml
@@ -22,6 +22,8 @@ type t =
 type error = string * t option
 exception Protocol_error of error
 
+let make_error ?value msg = (msg, value)
+
 let to_string_hum t = sexp_of_t t |> Sexp.to_string_hum
 let error_to_string_hum: error -> string = function
   | (s, Some t) -> Printf.sprintf "%s. T: '%s'" s (to_string_hum t)

--- a/runtime/runtime.ml
+++ b/runtime/runtime.ml
@@ -53,6 +53,9 @@ module type Driver = sig
       this is the only exception raised when deserializing *)
   exception Protocol_error of error
 
+  (** Construct an error to be raised from a custom parser. *)
+  val make_error: ?value: t -> string -> error
+
   (** Convert an error type to a human readable string *)
   val error_to_string_hum: error -> string
 


### PR DESCRIPTION
I only noticed now we're missing a way of constructing `error` from client code, which is needed when writing custom parsers.  Not sure this is how you prefer it, we could also expose the `raise_errorf` function, which is maybe more convenient but less general.

This is a follow up to #13 and #16.