### PR TITLE
Provide of_json_exn

### DIFF
--- a/drivers/json/json.ml
+++ b/drivers/json/json.ml
@@ -59,5 +59,5 @@ module Yojson = struct
 end
 
 (* Allow referencing Json.t in structures. *)
-let of_json t = t
+let of_json_exn t = t
 let to_json t = t

--- a/drivers/json/json.mli
+++ b/drivers/json/json.mli
@@ -7,5 +7,5 @@ module Yojson : sig
   val to_yojson: t -> t
 end
 
-val of_json: t -> t
+val of_json_exn: t -> t
 val to_json: t -> t


### PR DESCRIPTION
I think this is needed to be able to have a Json.t inside some types that will be derived.