### PR TITLE
Support result type

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,9 @@
 Changes marked with '*' indicates a changes that breaks backward compatibility
 [ ] Support extensible polymorphic variants
 
+5.2.0
+[x] Support Pervasive result
+
 5.1.0
 [x] Add of_<driver>_exn for deserializing of Driver.t
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Ppx protocol conv (de)serializers using deriving, which allows for
 plugable
 (de)serializers. [Api](https://andersfugmann.github.io/ppx_protocol_conv).
 
-This page contains an simple overview of functionality provided. More
-information is available in the [wiki pages](https://github.com/andersfugmann/ppx_protocol_conv/wiki)
+This page contains an simple overview of functionality provided.
+More information is available in the [wiki pages](https://github.com/andersfugmann/ppx_protocol_conv/wiki)
 
 [![Build Status](https://travis-ci.org/andersfugmann/ppx_protocol_conv.svg?branch=master)](https://travis-ci.org/andersfugmann/ppx_protocol_conv)
 

--- a/drivers/json/test/unittest.expected
+++ b/drivers/json/test/unittest.expected
@@ -241,3 +241,7 @@ null
 [ "aa", { "b": [ "aa", { "b": [ "B", 5 ], "A": "a" } ], "A": "a" } ]
 === Test__Test_variant.Poly ===
 [ "aaa", 5 ]
+=== Test__Test_result.Option.Ok ===
+[ "Ok", 2 ]
+=== Test__Test_result.Option.Error ===
+[ "Error", "Error string" ]

--- a/drivers/jsonm/test/unittest.expected
+++ b/drivers/jsonm/test/unittest.expected
@@ -1093,3 +1093,17 @@
     5
   ]
 ]
+=== Test__Test_result.Option.Ok ===
+[
+  [
+    "Ok",
+    2
+  ]
+]
+=== Test__Test_result.Option.Error ===
+[
+  [
+    "Error",
+    "Error string"
+  ]
+]

--- a/drivers/msgpack/msgpack.ml
+++ b/drivers/msgpack/msgpack.ml
@@ -1,10 +1,7 @@
 module Driver : Ppx_protocol_driver.Driver with type t = Msgpck.t = struct
   type t = Msgpck.t
 
-  let to_string_hum t =
-    let b = Buffer.create 64 in
-    Msgpck.pp (Format.formatter_of_buffer b ) t;
-    Buffer.contents b
+  let to_string_hum t = Format.asprintf "%a" Msgpck.pp t
 
   let of_list = Msgpck.of_list
   let to_list = Msgpck.to_list

--- a/drivers/msgpack/test/unittest.expected
+++ b/drivers/msgpack/test/unittest.expected
@@ -1,19 +1,19 @@
 === Test__Test_arrays.SingleElem ===
-
+[]
 === Test__Test_arrays.SingleElem ===
-
+[2]
 === Test__Test_arrays.Longarray ===
-
+[4, 2, 3, 1]
 === Test__Test_arrays.EmptyInsideRec ===
-
+{c: c, V: [], a: a}
 === Test__Test_arrays.SingleInsideRec ===
-
+{c: c, V: [2], a: a}
 === Test__Test_arrays.MultiInsideRec ===
-
+{c: c, V: [4, 2, 3, 1], a: a}
 === Test__Test_arrays.ArrayOfArrays ===
-
+{a: [[2, 3], [4, 5]]}
 === Test__Test_arrays.ArrayOfArrays2 ===
-
+[[], [[], [2], [3, 4]], [[]], [[2]]]
 === Tuple ===
 [[10, [20, 30, 40], [s50, s60, s70], [[100, 200], [300, 400], [500, 600]]],
  [11, [21, 31, 41], [s51, s61, s71], [[101, 201], [301, 401], [501, 601]]],
@@ -40,108 +40,112 @@
  [{a_string: s2, a_int: 2}, {a_string: s3, a_int: 3},
   {a_string: s4, a_int: 4}], t_a: {a_string: s1, a_int: 1}}
 === list ===
-
+{a: [1, 2, 3]}
 === Lists ===
 {l:
  [[A, [1, 2, 3]], [B, [[1, 2], [3, 4, 5], [2]], [3, 1], 5],
   [C, [1, 2, 3], [3, 4, 5]]], c: [100, 101, 102, 103], b:
  [[8, 9], [10, 20, 30, 40]], a: [[1, 2, 3], [], [10, 20, 30, 40], [100, 101]]}
 === array ===
-
+{a: [1, 2, 3]}
 === Test__Test_lists.SingleElem ===
-
+[]
 === Test__Test_lists.SingleElem ===
-
+[2]
 === Test__Test_lists.Longlist ===
-
+[4, 2, 3, 1]
 === Test__Test_lists.EmptyInsideRec ===
-
+{c: c, V: [], a: a}
 === Test__Test_lists.SingleInsideRec ===
-
+{c: c, V: [2], a: a}
 === Test__Test_lists.MultiInsideRec ===
-
+{c: c, V: [4, 2, 3, 1], a: a}
 === Test__Test_lists.ListOfLists ===
-
+{a: [[2, 3], [4, 5]]}
 === Test__Test_lists.ListOfLists2 ===
-
+[[], [[], [2], [3, 4]], [[]], [[2]]]
 === Test__Test_nonrec.Nonrec ===
-
+[A, [Cons, 4, [Cons, 3, Nil]]]
 === Test__Test_nonrec.Nonrec2 ===
-
+[Cons, 4, [Cons, 3, Nil]]
 === None ===
-
+()
 === Some None ===
-
+{__option: ()}
 === Some Some None ===
-
+{__option: {__option: ()}}
 === Some Some Some Unit ===
-
+{__option: {__option: {__option: {__option: ()}}}}
 === simple ===
-
+5
 === record ===
-
+{a: 5}
 === multiple ===
-
+[5, 5, true]
 === reference ===
-
+{a: {a: 5}}
 === recursive ===
-
+{c: {b: {a: 5}}}
 === Test__Test_poly.Simple ===
-
+[A, [B, 5], [C, [6, 7]], [D, [8, 9]]]
 === Test__Test_poly.Tree ===
-
+[Node, [[Node, [Leaf, 3, Leaf]], 10, Leaf]]
 === Test__Test_poly.MutualRecursion ===
-
+[T1, [V, [T, [V, [V1, [V1, [V1, [V0, 5]]]]]]]]
 === Test__Test_poly.InsideRec ===
-
+{c: c, V: A, a: a}
 === Test__Test_record.RecordList ===
-
+{objects: [{key: 1}, {key: 2}]}
 === Test__Test_record.SimpleRecord ===
 {HostId: SDsd, RequestId: sdfsd, Endpoint: (), Bucket: (), Message: Message,
  Code: Error}
 === Test__Test_sig.Test_sig ===
-
+{x: [A, [[A, 7], 7, 7, [B, 0.7], 7]]}
 === Test__Test_sig.Test_sig2 ===
-
+[1, 2., 3.0, (), [A, 1], {c: 3.0, b: 2., a: 1}, [A, 1]]
 === Test__Test_types.S3 ===
-
+{Contents: [{ETag: Etag, StorageClass: STANDARD}], Prefix: prefix}
 === Test__Test_types.Types ===
 {baz:
  {y_yd: [Variant_two1, 1], y_yc: [three, [100, 200, 300]], y_b:
   [two, [10, 20, 30]], y_a: 2}, bar: one, foo: 1}
 === Test__Test_unit.Some Some Some true ===
-
+true
 === Test__Test_unit.Some Some None ===
-
+{__option: {__option: ()}}
 === Test__Test_unit.Some None ===
-
+{__option: ()}
 === Test__Test_unit.None ===
-
+()
 === Test__Test_unit.Some Some Some true ===
-
+{a: true}
 === Test__Test_unit.Some Some None ===
-
+{a: {__option: {__option: ()}}}
 === Test__Test_unit.Some None ===
-
+{a: {__option: ()}}
 === Test__Test_unit.None ===
-
+{a: ()}
 === Test__Test_unit.unit option option list option option ===
-
+[{__option: {__option: ()}}, {__option: ()}, ()]
 === Test__Test_unit.confuse deserialization by using reserved word ===
-
+{o: {option: true}}
 === Test__Test_variant.Simple ===
-
+[A, [B, 5], [C, 6, 7], [D, [8, 9]]]
 === Test__Test_variant.Tuple ===
-
+[A, [3, 4]]
 === Test__Test_variant.Tree ===
-
+[Node, [Node, Leaf, 3, Leaf], 10, Leaf]
 === Test__Test_variant.MutualRecursion ===
-
+[T1, [V, [T, [V, [V1, [V1, [V1, [V0, 5]]]]]]]]
 === Test__Test_variant.InsideRec ===
-
+{c: c, V: A, a: a}
 === Test__Test_variant.InlineRecord ===
-
+[A, {a: a}]
 === Test__Test_variant.InlineRecord2 ===
-
+[aa, {b: [aa, {b: [B, 5], A: a}], A: a}]
 === Test__Test_variant.Poly ===
-
+[aaa, 5]
+=== Test__Test_result.Option.Ok ===
+[Ok, 2]
+=== Test__Test_result.Option.Error ===
+[Error, Error string]

--- a/drivers/xml_light/test/unittest.expected
+++ b/drivers/xml_light/test/unittest.expected
@@ -755,3 +755,13 @@ B
 aaa
   <p>5</p>
 </variant>
+=== Test__Test_result.Option.Ok ===
+<variant>
+Ok
+  <p>2</p>
+</variant>
+=== Test__Test_result.Option.Error ===
+<variant>
+Error
+  <p>Error string</p>
+</variant>

--- a/drivers/yaml/test/unittest.expected
+++ b/drivers/yaml/test/unittest.expected
@@ -586,3 +586,11 @@ a: a
 - aaa
 - 5
 
+=== Test__Test_result.Option.Ok ===
+- Ok
+- 2
+
+=== Test__Test_result.Option.Error ===
+- Error
+- Error string
+

--- a/drivers/yaml/yaml.ml
+++ b/drivers/yaml/yaml.ml
@@ -1,8 +1,7 @@
 module Yaml = Global.Yaml
 module Driver : Ppx_protocol_driver.Driver with type t = Yaml.value = struct
   type t = Yaml.value
-  let to_string_hum t =
-    Yaml.to_string_exn t
+  let to_string_hum t = Format.asprintf "%a" Yaml.pp t
 
   let of_list l = `A l
   let to_list = function `A l -> l | _ -> failwith "List expected"

--- a/ppx/test/test_driver.ml
+++ b/ppx/test/test_driver.ml
@@ -98,6 +98,15 @@ let to_lazy_t: (t -> 'a) -> t -> 'a lazy_t = fun to_value_fun t ->
 let of_lazy_t: ('a -> t) -> 'a lazy_t -> t = fun of_value_fun v ->
   Lazy.force v |> of_value_fun
 
+let to_result:  (t -> 'a) -> (t -> 'b) -> t -> ('a, 'b) Result.t = fun to_ok to_err -> function
+  | Variant ("Ok", [ok]) -> Ok (to_ok ok)
+  | Variant ("Error", [err]) -> Error (to_err err)
+  | e -> raise_errorf e "Variant OK | Error expected"
+
+let of_result:  ('a -> t) -> ('b -> t) -> ('a, 'b) Result.t -> t = fun of_ok of_err -> function
+  | Ok ok -> Variant ("Ok", [of_ok ok])
+  | Error err -> Variant ("Error", [of_err err])
+
 let to_int = function Int i -> i | e -> raise_errorf e "Int type not found"
 let of_int i = Int i
 

--- a/ppx/test/unittest.expected
+++ b/ppx/test/unittest.expected
@@ -266,3 +266,7 @@
     (A (String a))))))
 === Test__Test_variant.Poly ===
 (Variant aaa ((Int 5)))
+=== Test__Test_result.Option.Ok ===
+(Variant Ok ((Int 2)))
+=== Test__Test_result.Option.Error ===
+(Variant Error ((String "Error string")))

--- a/runtime/runtime.ml
+++ b/runtime/runtime.ml
@@ -29,7 +29,7 @@ module Tuple_out = struct
 end
 
 module Variant_in = struct
-  type (_, _) t = Variant: string * ('a, 'constr, 'c) Tuple_in.t  * 'constr -> ('a, 'c) t
+  type (_, _) t = Variant: string * ('a, 'constr, 'c) Tuple_in.t * 'constr -> ('a, 'c) t
 end
 
 (** Signature for a driver. Serialization function are on the form [of_XXX] and
@@ -82,6 +82,8 @@ module type Driver = sig
   val of_array:   ('a -> t) -> 'a array -> t
   val to_lazy_t:  (t -> 'a) -> t -> 'a lazy_t
   val of_lazy_t:  ('a -> t) -> 'a lazy_t -> t
+  val to_result:  (t -> 'a) -> (t -> 'b) -> t -> ('a, 'b) result
+  val of_result:  ('a -> t) -> ('b -> t) -> ('a, 'b) result -> t
   val to_int:     t -> int
   val of_int:     int -> t
   val to_int32:   t -> int32

--- a/test/test_result.ml
+++ b/test/test_result.ml
@@ -1,0 +1,25 @@
+open Sexplib.Std
+module Make(Driver: Testable.Driver) = struct
+  module M = Testable.Make(Driver)
+  let result_of_sexp = Base.Result.t_of_sexp
+  let sexp_of_result = Base.Result.sexp_of_t
+
+  module Result_ok : M.Testable = struct
+    let name = __MODULE__ ^ ".Option.Ok"
+    type t = (int, string) result
+    [@@deriving protocol ~driver:(module Driver), sexp]
+    let t = Ok 2
+  end
+
+  module Result_error : M.Testable = struct
+    let name = __MODULE__ ^ ".Option.Error"
+    type t = (int, string) result
+    [@@deriving protocol ~driver:(module Driver), sexp]
+    let t = Error "Error string"
+  end
+
+  let unittest = __MODULE__, [
+      M.test (module Result_ok);
+      M.test (module Result_error);
+    ]
+end

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -15,11 +15,10 @@ module Make(Driver: Testable.Driver) = struct
       storage_class: storage_class [@key "StorageClass"];
       etag: string [@key "ETag"];
     }
-    and result = {
+    and t = {
       prefix: string option [@key "Prefix"];
       contents: content list [@key "Contents"];
     }
-    and t = result
     [@@deriving protocol ~driver:(module Driver), sexp]
 
     let t = { prefix = Some "prefix";

--- a/test/unittest.ml
+++ b/test/unittest.ml
@@ -20,6 +20,7 @@ module Make(Driver : Testable.Driver) = struct
       (module Test_types);
       (module Test_unit);
       (module Test_variant);
+      (module Test_result);
     ]
 
   (* Create a list of tests *)


### PR DESCRIPTION
Informational PR only. 

The problem is that this will not work if the user code has local definitions of a type named 'result'. 