### PR TITLE
Support ppxlib 0.9.0 (+ OCaml 4.10 for free)

### DIFF
--- a/ppx_protocol_conv.opam
+++ b/ppx_protocol_conv.opam
@@ -11,11 +11,11 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04"}
-  "base" {< "v0.13"}
+  "base"
   "dune" {>= "1.2"}
-  "ppxlib" {>= "0.3.0" & < "0.9.0"}
-  "ppx_sexp_conv" {with-test & < "v0.13"}
-  "sexplib" {with-test & < "v0.13"}
+  "ppxlib" {>= "0.9.0"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis:

--- a/ppx_protocol_conv_json.opam
+++ b/ppx_protocol_conv_json.opam
@@ -14,10 +14,10 @@ depends: [
   "ppx_protocol_conv" {= version}
   "yojson" {>= "1.5.0" & < "2.0.0"}
   "dune" {>= "1.2"}
-  "ppx_expect" {< "v0.13"}
-  "ppx_inline_test" {< "v0.13"}
-  "ppx_sexp_conv" {with-test & < "v0.13"}
-  "sexplib" {with-test & < "v0.13"}
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Json driver for Ppx_protocol_conv"

--- a/ppx_protocol_conv_jsonm.opam
+++ b/ppx_protocol_conv_jsonm.opam
@@ -14,8 +14,8 @@ depends: [
   "ppx_protocol_conv" {= version}
   "ezjsonm"
   "dune" {>= "1.2"}
-  "ppx_sexp_conv" {with-test & < "v0.13"}
-  "sexplib" {with-test & < "v0.13"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Jsonm driver for Ppx_protocol_conv"

--- a/ppx_protocol_conv_msgpack.opam
+++ b/ppx_protocol_conv_msgpack.opam
@@ -14,8 +14,8 @@ depends: [
   "ppx_protocol_conv" {= version}
   "msgpck"
   "dune" {>= "1.2"}
-  "ppx_sexp_conv" {with-test & < "v0.13"}
-  "sexplib" {with-test & < "v0.13"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "MessagePack driver for Ppx_protocol_conv"

--- a/ppx_protocol_conv_xml_light.opam
+++ b/ppx_protocol_conv_xml_light.opam
@@ -14,8 +14,8 @@ depends: [
   "ppx_protocol_conv" {= version}
   "xml-light"
   "dune" {>= "1.2"}
-  "ppx_sexp_conv" {with-test & < "v0.13"}
-  "sexplib" {with-test & < "v0.13"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Xml driver for Ppx_protocol_conv"

--- a/ppx_protocol_conv_yaml.opam
+++ b/ppx_protocol_conv_yaml.opam
@@ -14,8 +14,8 @@ depends: [
   "dune" {>= "1.2"}
   "ppx_protocol_conv" {= version}
   "yaml" { >= "2.0.0"}
-  "ppx_sexp_conv" {with-test & < "v0.13"}
-  "sexplib" {with-test & < "v0.13"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
   "alcotest" {with-test & >= "0.8.0"}
 ]
 synopsis: "Json driver for Ppx_protocol_conv"


### PR DESCRIPTION
This PR add support for ppxlib 0.9.0 and the upcoming OCaml 4.10 all together (as ppxlib >= 0.9.0 is required for the OCaml 4.10 support)