### PR TITLE
Remove stdio dependency

### DIFF
--- a/ppx/ppx_protocol_conv.ml
+++ b/ppx/ppx_protocol_conv.ml
@@ -19,7 +19,7 @@ let raise_errorf ?loc fmt = Location.raise_errorf ?loc ("ppx_protocol_conv: " ^^
 let debug = false
 let debug fmt = match debug with
   | true -> eprintf (fmt ^^ "\n%!")
-  | false -> ifprintf Stdio.stderr fmt [@@warning "-32"]
+  | false -> ifprintf Caml.stderr fmt [@@warning "-32"]
 
 let string_of_ident_loc { loc; txt } =
   let rec inner = function


### PR DESCRIPTION
stdio used to be pulled in as a dependency of ppxlib 0.14.0. In ppxlib 0.15.0 it became a test-only dependency and therefore ppx_protocol_conv was marked `"ppxlib" {>= "0.9.0" & < "0.15.0"}`.  This removes the stdio dependency, which was only used in a single place.