### PR TITLE
Fix a missing dependency in ppx/dune

### DIFF
--- a/ppx/dune
+++ b/ppx/dune
@@ -2,7 +2,7 @@
  (name ppx_protocol_conv)
  (public_name ppx_protocol_conv)
  (kind ppx_deriver)
- (libraries base ppxlib)
+ (libraries base stdio ppxlib)
  (preprocess (pps ppxlib.metaquot))
  (synopsis "ppx to derive (de)serializers of a type")
 )


### PR DESCRIPTION
It seems that ppx_protocol_conv transitively depended on stdio through ppxlib but ppxlib doesn't depend on stdio anymore.

While preparing the 0.18.0 release I was going through some of our rev deps and stumbled upon this issue!