### PR TITLE
Avoid linking against ppxlib in jsonm driver

### DIFF
--- a/drivers/jsonm/dune
+++ b/drivers/jsonm/dune
@@ -1,6 +1,6 @@
 (library
  (name protocol_conv_jsonm)
  (public_name ppx_protocol_conv_jsonm)
- (libraries ppx_protocol_conv ppx_protocol_conv.runtime ppx_protocol_conv.driver ezjsonm)
+ (libraries ppx_protocol_conv.runtime ppx_protocol_conv.driver ezjsonm)
  (synopsis "jsonm (de)serialization driver for ppx_protocol_conv based on ezjsonm")
 )


### PR DESCRIPTION
Similar change to 1be9d66.

Did not run the project tests with this patch, but it seems to work on our codebase (see https://github.com/dividat/playos/pull/206). 